### PR TITLE
doc(setup): add client redirect to Requestly rules

### DIFF
--- a/docs/setup-instructions.md
+++ b/docs/setup-instructions.md
@@ -77,6 +77,16 @@ You can add the following rules to redirect to where the files should be served 
         },
         "status": "Inactive",
         "to": "http://localhost:9000/"
+      },
+      {
+        "from":"http://162.243.2.41/",
+        "source":{
+            "key":"Url",
+            "operator":"Contains",
+            "value":"/client/"
+        },
+        "status":"Inactive",
+        "to":"http://localhost:9000/"
       }
     ],
     "ruleType": "Replace",


### PR DESCRIPTION
I'm adding a rule to the Requestly portion of the setup-instructions doc. I needed this rule to be able to use the chrome debugger on testnet.